### PR TITLE
[Spark 3] Use partition-aware policy for Spark load balancing and partitioning

### DIFF
--- a/.arcconfig
+++ b/.arcconfig
@@ -1,0 +1,8 @@
+{
+  "phabricator.uri" : "https://phabricator.dev.yugabyte.com/",
+  "repository.callsign": "SCC",
+  "git:arc.feature.start.default" : "origin/yb-3.0",
+  "arc.land.onto.default": "yb-3.0",
+  "arc.land.remote.default": "origin",
+  "arc.feature.start.default" : "yb-3.0"
+}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+3.0.0-yb-1
+ * Add load balancing policy for YugaByte
+
 3.0.0
  * Update Spark to 3.0.1 and commons-lang to 3.9
  * Remove full table scans performance regression (SPARKC-614)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -199,3 +199,17 @@ Apache License
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+   The following only applies to changes made to this file as part of YugaByte development.
+
+   Portions Copyright (c) YugaByte, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+   in compliance with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software distributed under the License
+   is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+   or implied.  See the License for the specific language governing permissions and limitations
+   under the License.

--- a/build.sbt
+++ b/build.sbt
@@ -12,11 +12,11 @@ ThisBuild / scalacOptions ++= Seq("-target:jvm-1.8")
 
 // Publishing Info
 ThisBuild / credentials ++= Publishing.Creds
-ThisBuild / homepage := Some(url("https://github.com/datastax/spark-cassandra-connector"))
+ThisBuild / homepage := Some(url("https://github.com/yugabyte/spark-cassandra-connector"))
 ThisBuild / licenses := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt") )
-ThisBuild / organization := "com.datastax.spark"
-ThisBuild / organizationName := "Datastax"
-ThisBuild / organizationHomepage := Some(url("https://www.datastax.com"))
+ThisBuild / organization := "com.yugabyte.spark"
+ThisBuild / organizationName := "Yugabyte"
+ThisBuild / organizationHomepage := Some(url("https://www.yugabyte.com"))
 ThisBuild / pomExtra := Publishing.OurDevelopers
 ThisBuild / pomIncludeRepository := { _ => false }
 ThisBuild / publishMavenStyle := true
@@ -41,9 +41,7 @@ lazy val assemblySettings = Seq(
     case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
     case PathList("META-INF", xs @ _*) => MergeStrategy.last
     case "module-info.class" => MergeStrategy.discard
-    case x =>
-      val oldStrategy = (assemblyMergeStrategy in assembly).value
-      oldStrategy(x)
+    case x => MergeStrategy.first
   },
   assembly / assemblyOption := (assemblyOption in assembly).value.copy(includeScala = false),
   assembly / assemblyShadeRules := {

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
@@ -15,6 +15,7 @@ import com.datastax.oss.driver.internal.core.connection.ExponentialReconnectionP
 import com.datastax.oss.driver.internal.core.ssl.DefaultSslEngineFactory
 import com.datastax.spark.connector.rdd.ReadConf
 import com.datastax.spark.connector.util.{ConfigParameter, DeprecatedConfigParameter, ReflectionUtil}
+import com.yugabyte.oss.driver.internal.core.loadbalancing.PartitionAwarePolicy
 import org.apache.spark.{SparkConf, SparkEnv, SparkFiles}
 import org.slf4j.LoggerFactory
 
@@ -83,7 +84,7 @@ object DefaultConnectionFactory extends CassandraConnectionFactory {
     def ipBasedConnectionProperties(ipConf: IpBasedContactInfo) = (builder: PDCLB) => {
       builder
         .withStringList(CONTACT_POINTS, ipConf.hosts.map(h => s"${h.getHostString}:${h.getPort}").toList.asJava)
-        .withClass(LOAD_BALANCING_POLICY_CLASS, classOf[LocalNodeFirstLoadBalancingPolicy])
+        .withClass(LOAD_BALANCING_POLICY_CLASS, classOf[PartitionAwarePolicy])
 
       def clientAuthEnabled(value: Option[String]) =
         if (ipConf.cassandraSSLConf.clientAuthEnabled) value else None
@@ -123,6 +124,7 @@ object DefaultConnectionFactory extends CassandraConnectionFactory {
 
     val initialBuilder = CqlSession.builder()
 
+    logger.info(s"Creating CqlSession from contact info ${conf.contactInfo}");
     val builderWithContactInfo =  conf.contactInfo match {
       case ipConf: IpBasedContactInfo =>
         ipConf.authConf.authProvider.fold(initialBuilder)(initialBuilder.withAuthProvider)

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
@@ -11,7 +11,7 @@ import org.apache.spark.SparkConf
   * @param splitSizeInMB size of Cassandra data to be read in a single Spark task; 
   *                      determines the number of partitions, but ignored if `splitCount` is set
   * @param fetchSizeInRows number of CQL rows to fetch in a single round-trip to Cassandra
-  * @param consistencyLevel consistency level for reads, default LOCAL_ONE;
+  * @param consistencyLevel consistency level for reads, default YB_CONSISTENT_PREFIX;
   *                         higher consistency level will disable data-locality
   * @param taskMetricsEnabled whether or not enable task metrics updates (requires Spark 1.2+)
   * @param readsPerSec maximum read throughput allowed per single core in requests/s while
@@ -70,7 +70,7 @@ object ReadConf extends Logging {
   val ConsistencyLevelParam = ConfigParameter[ConsistencyLevel](
     name = "spark.cassandra.input.consistency.level",
     section = ReferenceSection,
-    default = DefaultConsistencyLevel.LOCAL_ONE,
+    default = ConsistencyLevel.YB_CONSISTENT_PREFIX,
     description = """Consistency level to use when reading	""")
 
   val TaskMetricParam = ConfigParameter[Boolean](

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionGenerator.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionGenerator.scala
@@ -1,5 +1,9 @@
 package com.datastax.spark.connector.rdd.partitioner
 
+import java.net.InetSocketAddress
+import java.util.NavigableMap
+import java.util.TreeMap;
+
 import com.datastax.oss.driver.api.core.CqlIdentifier
 import com.datastax.oss.driver.api.core.metadata.TokenMap
 import com.datastax.oss.driver.api.core.metadata.token.{TokenRange => DriverTokenRange}
@@ -12,10 +16,12 @@ import com.datastax.spark.connector.util.DriverUtil._
 import com.datastax.spark.connector.util.{DriverUtil, Logging}
 import com.datastax.spark.connector.ColumnSelector
 import com.datastax.spark.connector.cql.{CassandraConnector, TableDef}
-import com.datastax.spark.connector.rdd.partitioner.dht.{Token, TokenFactory}
+import com.datastax.spark.connector.rdd.partitioner.dht.{LongToken, Token, TokenFactory}
 import com.datastax.spark.connector.writer.RowWriterFactory
 import org.apache.spark.sql.connector.read.InputPartition
-
+import com.yugabyte.oss.driver.internal.core.loadbalancing.PartitionAwarePolicy
+import com.yugabyte.oss.driver.api.core.DefaultPartitionMetadata
+import com.yugabyte.oss.driver.api.core.PartitionMetadata
 
 /** Creates CassandraPartitions for given Cassandra table */
 private[connector] class CassandraPartitionGenerator[V, T <: Token[V]](
@@ -79,7 +85,37 @@ private[connector] class CassandraPartitionGenerator[V, T <: Token[V]](
 
   def partitions: Seq[CassandraPartition[V, T]] = {
     val hostAddresses = new NodeAddresses(connector)
-    val tokenRanges = describeRing
+    // Try to get table-specific partition map from table metadata (for YugaByte).
+    val partitionMap: NavigableMap[Integer, PartitionMetadata] = connector withSessionDo { session =>
+      val partitionMetadata = session.getMetadata.getDefaultPartitionMetadata
+      if (!partitionMetadata.isPresent()) {
+        new TreeMap[Integer, PartitionMetadata]()
+      } else {
+        partitionMetadata.get.asInstanceOf[DefaultPartitionMetadata]
+        .getTableSplitMetadata(tableDef.keyspaceName, tableDef.tableName).getPartitionMap()
+      }
+    }
+
+    val tokenRanges : Seq[TokenRange] = if (partitionMap != null) {
+      // Compute map from (start) token to corresponding hosts based on the partition map.
+      // Converting token map into Sequence of TokenRanges describing the ring for this table.
+      var ranges = partitionMap.values.toSeq.map { partition =>
+        val startToken = tokenFactory.tokenFromString(PartitionAwarePolicy.YBToCqlHashCode(partition.getStartKey()).toString)
+        val endToken = tokenFactory.tokenFromString(PartitionAwarePolicy.YBToCqlHashCode(partition.getEndKey()).toString)
+        val hosts = partition.getHosts().map(_.getEndPoint().resolve.asInstanceOf[InetSocketAddress].getAddress).toSet
+        new TokenRange(startToken, endToken, hosts, tokenFactory)
+      }
+      ranges match {
+        case head #:: rest =>
+          // If the partition map is empty, fall back to Cassandra way of choosing ranges
+          if (head.replicas.isEmpty)
+            ranges = describeRing
+      }
+      ranges
+    } else {
+      // If YugaByte partition map is missing, default to Cassandra behavior.
+      describeRing
+    }
     val endpointCount = tokenRanges.map(_.replicas).reduce(_ ++ _).size
     if (endpointCount == 0)
       throw new IllegalArgumentException(s"Could not retrieve endpoints for the given table " +

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -16,7 +16,7 @@ import org.apache.spark.SparkConf
   * @param batchGroupingBufferSize the number of distinct batches that can be buffered before
   *                        they are written to Cassandra
   * @param batchGroupingKey which rows can be grouped into a single batch
-  * @param consistencyLevel consistency level for writes, default LOCAL_QUORUM
+  * @param consistencyLevel consistency level for writes, default YB_STRONG.
   * @param ifNotExists inserting a row should happen only if it does not already exist
   * @param parallelismLevel number of batches to be written in parallel
   * @param ttl       the default TTL value which is used when it is defined (in seconds)
@@ -63,7 +63,7 @@ object WriteConf {
   val ConsistencyLevelParam = ConfigParameter[ConsistencyLevel](
     name = "spark.cassandra.output.consistency.level",
     section = ReferenceSection,
-    default = DefaultConsistencyLevel.LOCAL_QUORUM,
+    default = ConsistencyLevel.YB_STRONG,
     description = """Consistency level for writing""")
 
   val BatchSizeRowsParam = ConfigParameter[Option[Int]](

--- a/driver/src/main/scala/com/datastax/spark/connector/cql/LocalNodeFirstLoadBalancingPolicy.scala
+++ b/driver/src/main/scala/com/datastax/spark/connector/cql/LocalNodeFirstLoadBalancingPolicy.scala
@@ -48,7 +48,7 @@ class LocalNodeFirstLoadBalancingPolicy(context: DriverContext, profileName: Str
 
   private def distance(node: Node): NodeDistance =
     if (nodeFilter.forall(_.test(node)) && node.getDatacenter == dcToUse) {
-      sameDCNodeDistance(node)
+      NodeDistance.LOCAL
     } else {
       // this insures we keep remote hosts out of our list entirely, even when we get notified of newly joined nodes
       NodeDistance.IGNORED
@@ -114,11 +114,7 @@ class LocalNodeFirstLoadBalancingPolicy(context: DriverContext, profileName: Str
     val replicas = getReplicas(request, session)
       .filter(node => node.getState == NodeState.UP && distance(node) != NodeDistance.IGNORED)
 
-    val nodes = if (replicas.nonEmpty) {
-      replicaAwareQueryPlan(request, replicas)
-    } else {
-      tokenUnawareQueryPlan(request)
-    }
+    val nodes = tokenUnawareQueryPlan(request)
     new QueryPlan(nodes: _*)
   }
 
@@ -142,12 +138,6 @@ class LocalNodeFirstLoadBalancingPolicy(context: DriverContext, profileName: Str
   }
 
   override def onDown(node: Node): Unit = {}
-
-  private def sameDCNodeDistance(node: Node): NodeDistance =
-    if (isLocalHost(node))
-      NodeDistance.LOCAL
-    else
-      NodeDistance.REMOTE
 }
 
 object LocalNodeFirstLoadBalancingPolicy {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,7 +42,7 @@ object Dependencies
     val junit = "junit" % "junit" % JUnit
     val junitInterface = "com.novocode" % "junit-interface" % JUnitInterface
     val scalaTest = "org.scalatest" %% "scalatest" % ScalaTest
-    val driverMapperProcessor = "com.datastax.oss" % "java-driver-mapper-processor" % DataStaxJavaDriver
+    val driverMapperProcessor = "com.yugabyte" % "java-driver-mapper-processor" % DataStaxJavaDriver
   }
 
   object TestConnector {
@@ -73,8 +73,8 @@ object Dependencies
   }
 
   object Driver {
-    val driverCore = "com.datastax.oss" % "java-driver-core-shaded" % DataStaxJavaDriver driverCoreExclude()
-    val driverMapper = "com.datastax.oss" % "java-driver-mapper-runtime" % DataStaxJavaDriver driverCoreExclude()
+    val driverCore = "com.yugabyte" % "java-driver-core-shaded" % DataStaxJavaDriver driverCoreExclude()
+    val driverMapper = "com.yugabyte" % "java-driver-mapper-runtime" % DataStaxJavaDriver driverCoreExclude()
 
     val commonsLang3 = "org.apache.commons" % "commons-lang3" % Versions.CommonsLang3
     val paranamer = "com.thoughtworks.paranamer" % "paranamer" % Versions.Paranamer

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -68,100 +68,20 @@ object Publishing extends sbt.librarymanagement.DependencyBuilders {
   val OurScmInfo =
     Some(
       ScmInfo(
-        url("https://github.com/datastax/spark-cassandra-connector"),
-        "scm:git@github.com:datastax/spark-cassandra-connector.git"
+        url("https://github.com/yugabyte/spark-cassandra-connector"),
+        "scm:git@github.com:yugabyte/spark-cassandra-connector.git"
       )
     )
 
   val OurDevelopers =
       <developers>
         <developer>
-          <id>pkolaczk</id>
-          <name>Piotr Kolaczkowski</name>
-          <url>http://github.com/pkolaczk</url>
-          <organization>DataStax</organization>
-          <organizationUrl>http://www.datastax.com/</organizationUrl>
-        </developer>
-        <developer>
-          <id>jacek-lewandowski</id>
-          <name>Jacek Lewandowski</name>
-          <url>http://github.com/jacek-lewandowski</url>
-          <organization>DataStax</organization>
-          <organizationUrl>http://www.datastax.com/</organizationUrl>
-        </developer>
-        <developer>
-          <id>helena</id>
-          <name>Helena Edelson</name>
-          <url>http://github.com/helena</url>
-          <organization>DataStax</organization>
-          <organizationUrl>http://www.datastax.com/</organizationUrl>
-        </developer>
-        <developer>
-          <id>alexliu68</id>
-          <name>Alex Liu</name>
-          <url>http://github.com/alexliu68</url>
-          <organization>DataStax</organization>
-          <organizationUrl>http://www.datastax.com/</organizationUrl>
-        </developer>
-        <developer>
-          <id>RussellSpitzer</id>
-          <name>Russell Spitzer</name>
-          <url>http://github.com/RussellSpitzer</url>
-          <organization>DataStax</organization>
-          <organizationUrl>http://www.datastax.com/</organizationUrl>
-        </developer>
-        <developer>
-          <id>artem-aliev</id>
-          <name>Artem Aliev</name>
-          <url>http://github.com/artem-aliev</url>
-          <organization>DataStax</organization>
-          <organizationUrl>http://www.datastax.com/</organizationUrl>
-        </developer>
-        <developer>
-          <id>bcantoni</id>
-          <name>Brian Cantoni</name>
-          <url>http://github.com/bcantoni</url>
-          <organization>DataStax</organization>
-          <organizationUrl>http://www.datastax.com/</organizationUrl>
-        </developer>
-        <developer>
-          <id>jtgrabowski</id>
-          <name>Jaroslaw Grabowski</name>
-          <url>http://github.com/jtgrabowski</url>
-          <organization>DataStax</organization>
-          <organizationUrl>http://www.datastax.com/</organizationUrl>
+          <name>YugaByte Development Team</name>
+          <email>info@yugabyte.com</email>
+          <organization>YugaByte, Inc.</organization>
+          <organizationUrl>https://www.yugabyte.com</organizationUrl>
         </developer>
       </developers>
-      <contributors>
-        <contributor>
-          <name>Andrew Ash</name>
-          <url>http://github.com/ash211</url>
-        </contributor>
-        <contributor>
-          <name>Luis Angel Vicente Sanchez</name>
-          <url>http://github.com/lvicentesanchez</url>
-        </contributor>
-        <contributor>
-          <name>Todd</name>
-          <url>http://github.com/tsindot</url>
-        </contributor>
-        <contributor>
-          <name>Li Geng</name>
-          <url>http://github.com/anguslee</url>
-        </contributor>
-        <contributor>
-          <name>Isk</name>
-          <url>http://github.com/criticaled</url>
-        </contributor>
-        <contributor>
-          <name>Holden Karau</name>
-          <url>http://github.com/holdenk</url>
-        </contributor>
-        <contributor>
-          <name>Philipp Hoffmann</name>
-          <url>http://github.com/philipphoffmann</url>
-        </contributor>
-      </contributors>
     
 
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -5,7 +5,7 @@ object Versions {
   val CommonsLang3    = "3.9"
   val Paranamer       = "2.8"
 
-  val DataStaxJavaDriver = "4.7.2"
+  val DataStaxJavaDriver = "4.6.0-yb-6"
 
   val ScalaCheck      = "1.14.0"
   val ScalaTest       = "3.0.8"


### PR DESCRIPTION
Summary:
This ports the following commit to 3,0-yb branch for Spark 3

commit c8fd00bd4596b88b099d04efd6abb0de851f8cc4
Author: Mihnea Iancu <mihnea@yugabyte.com>
Date:   Wed Nov 8 18:34:12 2017 -0800

    Use partition-aware policy for Spark load balancing and partitioning

    Summary:
    Use the YugaByte PartitionAwarePolicy inside Spark's LocalNodeFirstPolicy for queries.
    Update the CassandraPartitionGenerator to generate Spark partitions based on YugaByte's internal
    partitioning.

Test Plan: YB Spark tests

Reviewers: nikhil, mihnea

Reviewed By: mihnea

Subscribers: yql

Differential Revision: https://phabricator.dev.yugabyte.com/D9962