### PR TITLE
Check for empty string before substring()

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
@@ -121,9 +121,11 @@ private[connector] class BoundStatementBuilder[T](
       if (quoteJsonValue && columnValue != null && columnValue.isInstanceOf[String] &&
           internalWriter.unknownColumnNameSet.contains(columnName)) {
           var colVal = columnValue.asInstanceOf[String]
-          val firstChar = colVal.substring(0, 1)
-          if (firstChar != "\"" && !nullFillin) {
-            columnValue = "\"" + colVal + "\""
+          if (!colVal.isEmpty()) {
+            val firstChar = colVal.substring(0, 1)
+            if (firstChar != "\"" && !nullFillin) {
+              columnValue = "\"" + colVal + "\""
+            }
           }
       }
       bindColumn(boundStatement, columnName, columnType, columnValue)

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -5,7 +5,7 @@ object Versions {
   val CommonsLang3    = "3.9"
   val Paranamer       = "2.8"
 
-  val DataStaxJavaDriver = "4.6.0-yb-10"
+  val DataStaxJavaDriver = "4.6.0-yb-12"
 
   val ScalaCheck      = "1.14.0"
   val ScalaTest       = "3.0.8"


### PR DESCRIPTION
Check for empty string before invoking substring() on it.

Tests:
From `~/code/yugabyte-db/java/yb-cql-4x/`:
```
mvn test -Dtest=org.yb.loadtest.TestSpark3Jsonb
mvn test -Dtest=org.yb.loadtest.TestSpark3Locality
mvn test -Dtest=org.yb.loadtest.TestCassandraSpark3WordCount

```
Also, updated the build to use 4.6.0-yb-12 version of cassandra driver version.