### PR TITLE
Provide timeout for fetchSchema()

### DIFF
--- a/driver/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
+++ b/driver/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
@@ -1,6 +1,7 @@
 package com.datastax.spark.connector.cql
 
 import java.io.IOException
+import java.util.concurrent.TimeUnit;
 
 import com.datastax.oss.driver.api.core.`type`.{UserDefinedType => DriverUserDefinedType}
 import com.datastax.oss.driver.api.core.metadata.Metadata
@@ -404,7 +405,7 @@ object Schema extends Logging {
     def fetchSchema(metadata: => Metadata): Schema =
       Schema(fetchKeyspaces(metadata))
 
-    val scheme = fetchSchema(session.refreshSchema())
+    val scheme = fetchSchema(session.refreshSchemaWithTimeout(1, TimeUnit.MINUTES))
 
     logDebug(s"${scheme.keyspaces.size} keyspaces fetched: " +
       s"${scheme.keyspaces.map(_.keyspaceName).mkString("{", ",", "}")}")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3


### PR DESCRIPTION
git cherry-pick c740b589 into 3.0-yb branch AND update sbt version to 1.3.3

Original Summary of c740b589:
Original commit was f48ea58a2e4b4b17d581993a69c7fa703bd8efab

We have seen, during troubleshooting user's spark jobs, that `fetchSchema` call (without timeout) sometimes hung for over 10 hours. This may happen when the node Spark task connects to is under heavy load.

This revision utilizes the new API in Cassandra driver where timeout is provided to `fetchSchema` call. There would be no hung Spark task calling `fetchSchema` with this fix.

This is for 3.1-yb branch

Test Plan: Build against 4.6.0-yb-11 Cassandra driver.

Reviewers: nikhil, skumar, nkumar, ashetkar

Reviewed By: ashetkar

Subscribers: yql

Differential Revision: https://phabricator.dev.yugabyte.com/D18619