### PR TITLE
Add plugin in plugins.sbt to support publishSigned command

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")


### PR DESCRIPTION
Problem:
publishSigned was not getting recognised. 

Solution
Added the pgp plugin for it.