### PR TITLE
Fixes to 3.1-yb

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ ThisBuild / publishMavenStyle := true
 ThisBuild / publishTo := Publishing.Repository
 ThisBuild / scmInfo := Publishing.OurScmInfo
 ThisBuild / version := Publishing.Version
+ThisBuild / credentials += Credentials(Path.userHome / ".sbt" / ".sonatype_credentials")
 
 Global / resolvers ++= Seq(
   DefaultMavenRepository,

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
@@ -121,9 +121,11 @@ private[connector] class BoundStatementBuilder[T](
       if (quoteJsonValue && columnValue != null && columnValue.isInstanceOf[String] &&
           internalWriter.unknownColumnNameSet.contains(columnName)) {
           var colVal = columnValue.asInstanceOf[String]
-          val firstChar = colVal.substring(0, 1)
-          if (firstChar != "\"" && !nullFillin) {
-            columnValue = "\"" + colVal + "\""
+          if (!colVal.isEmpty()) {
+            val firstChar = colVal.substring(0, 1)
+            if (firstChar != "\"" && !nullFillin) {
+              columnValue = "\"" + colVal + "\""
+            }
           }
       }
       bindColumn(boundStatement, columnName, columnType, columnValue)

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -5,7 +5,7 @@ object Versions {
   val CommonsLang3    = "3.10"
   val Paranamer       = "2.8"
 
-  val DataStaxJavaDriver = "4.6.0-yb-11"
+  val DataStaxJavaDriver = "4.6.0-yb-12"
 
   val ScalaCheck      = "1.14.0"
   val ScalaTest       = "3.0.8"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")


### PR DESCRIPTION
- Check replicas for all token ranges to avoid `UnsupportedOperationException: empty.min`
- Cherry pick https://github.com/yugabyte/spark-cassandra-connector/commit/22c7d78a95220bf41635f04dc2d42ed8ade23c48
- Enable publish on maven.
