### PR TITLE
Insert 'USING TTL' and 'TIMESTAMP' into the UPDATE sql

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -137,6 +137,7 @@ class TableWriter[T] private (
     val whereClause = quotedColumnNames(primaryKey).map(c => s"$c = :$c").mkString(" AND ")
 
     logInfo(s"ABS: UPDATE ${quote(keyspaceName)}.${quote(tableName)} SET $setClause WHERE $whereClause $optionalClause")
+    Thread.currentThread().getStackTrace.foreach(ste => logInfo(s"    $ste"))
     s"UPDATE ${quote(keyspaceName)}.${quote(tableName)} SET $setClause WHERE $whereClause $optionalClause"
   }
 

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -136,6 +136,7 @@ class TableWriter[T] private (
     }
     val whereClause = quotedColumnNames(primaryKey).map(c => s"$c = :$c").mkString(" AND ")
 
+    println(s"ABS: UPDATE ${quote(keyspaceName)}.${quote(tableName)} SET $setClause WHERE $whereClause $optionalClause")
     s"UPDATE ${quote(keyspaceName)}.${quote(tableName)} SET $setClause WHERE $whereClause $optionalClause"
   }
 

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -136,7 +136,7 @@ class TableWriter[T] private (
     }
     val whereClause = quotedColumnNames(primaryKey).map(c => s"$c = :$c").mkString(" AND ")
 
-    println(s"ABS: UPDATE ${quote(keyspaceName)}.${quote(tableName)} SET $setClause WHERE $whereClause $optionalClause")
+    logInfo(s"ABS: UPDATE ${quote(keyspaceName)}.${quote(tableName)} SET $setClause WHERE $whereClause $optionalClause")
     s"UPDATE ${quote(keyspaceName)}.${quote(tableName)} SET $setClause WHERE $whereClause $optionalClause"
   }
 

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -44,6 +44,10 @@ class TableWriter[T] private (
 
     val ifNotExistsSpec = if (writeConf.ifNotExists) "IF NOT EXISTS " else ""
 
+    s"INSERT INTO ${quote(keyspaceName)}.${quote(tableName)} ($columnSpec) VALUES ($valueSpec) $ifNotExistsSpec$optionsSpec".trim
+  }
+
+  private lazy val optionsSpec: String = {
     val ttlSpec = writeConf.ttl match {
       case TTLOption(PerRowWriteOptionValue(placeholder)) => Some(s"""TTL :$placeholder""")
       case TTLOption(StaticWriteOptionValue(value)) => Some(s"TTL $value")
@@ -57,9 +61,7 @@ class TableWriter[T] private (
     }
 
     val options = List(ttlSpec, timestampSpec).flatten
-    val optionsSpec = if (options.nonEmpty) s"USING ${options.mkString(" AND ")}" else ""
-
-    s"INSERT INTO ${quote(keyspaceName)}.${quote(tableName)} ($columnSpec) VALUES ($valueSpec) $ifNotExistsSpec$optionsSpec".trim
+    if (options.nonEmpty) s"USING ${options.mkString(" AND ")}" else ""
   }
 
   private def deleteQueryTemplate(deleteColumns: ColumnSelector): String = {
@@ -136,9 +138,7 @@ class TableWriter[T] private (
     }
     val whereClause = quotedColumnNames(primaryKey).map(c => s"$c = :$c").mkString(" AND ")
 
-    logInfo(s"ABS: UPDATE ${quote(keyspaceName)}.${quote(tableName)} SET $setClause WHERE $whereClause $optionalClause")
-    Thread.currentThread().getStackTrace.foreach(ste => logInfo(s"    $ste"))
-    s"UPDATE ${quote(keyspaceName)}.${quote(tableName)} SET $setClause WHERE $whereClause $optionalClause"
+    s"UPDATE ${quote(keyspaceName)}.${quote(tableName)} $optionsSpec SET $setClause WHERE $whereClause $optionalClause"
   }
 
   private val isCounterUpdate =


### PR DESCRIPTION
(Changes from https://github.com/yugabyte/spark-cassandra-connector/pull/15 but for Spark Connector version 3.3.x)
- Insert `USING TTL` and `TIMESTAMP` into the _UPDATE_ sql
  - This resets the row-level ttl of the record to the given value
  - The same clause gets suffixed to the _INSERT_ statement generated by the connector but was missing for the _UPDATE_ case.
- Fixes the issue observed in https://yugabyte.atlassian.net/browse/CE-812
- Tested with [this test application](https://github.com/yugabyte/spark-cassandra-connector-tests) by changing the versions in the `pom.xml`