### PR TITLE
Update ycql driver version to 4.19

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/cql/AuthConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/AuthConf.scala
@@ -1,7 +1,7 @@
 package com.datastax.spark.connector.cql
 
 import com.datastax.oss.driver.api.core.auth.AuthProvider
-import com.datastax.oss.driver.internal.core.auth.ProgrammaticPlainTextAuthProvider
+import com.datastax.oss.driver.api.core.auth.ProgrammaticPlainTextAuthProvider
 import com.datastax.spark.connector.util.{ConfigParameter, ReflectionUtil}
 import org.apache.spark.SparkConf
 

--- a/driver/src/main/scala/com/datastax/spark/connector/cql/LocalNodeFirstLoadBalancingPolicy.scala
+++ b/driver/src/main/scala/com/datastax/spark/connector/cql/LocalNodeFirstLoadBalancingPolicy.scala
@@ -15,7 +15,7 @@ import com.datastax.oss.driver.api.core.session.{Request, Session}
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager
 import com.datastax.oss.driver.internal.core.util.Reflection
-import com.datastax.oss.driver.internal.core.util.collection.QueryPlan
+import com.datastax.oss.driver.internal.core.util.collection.SimpleQueryPlan
 import com.datastax.spark.connector.cql.LocalNodeFirstLoadBalancingPolicy.{LoadBalancingShuffleNodes, _}
 import com.datastax.spark.connector.util.DriverUtil.{toAddress, toOption}
 
@@ -115,7 +115,7 @@ class LocalNodeFirstLoadBalancingPolicy(context: DriverContext, profileName: Str
       .filter(node => node.getState == NodeState.UP && distance(node) != NodeDistance.IGNORED)
 
     val nodes = tokenUnawareQueryPlan(request)
-    new QueryPlan(nodes: _*)
+    new SimpleQueryPlan(nodes: _*)
   }
 
   override def onAdd(node: Node) {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -5,7 +5,7 @@ object Versions {
   val CommonsLang3    = "3.10"
   val Paranamer       = "2.8"
 
-  val DataStaxJavaDriver = "4.6.0-yb-12"
+  val DataStaxJavaDriver = "4.19.0-yb-1"
 
   val ScalaCheck      = "1.14.0"
   val ScalaTest       = "3.0.8"


### PR DESCRIPTION
## What
- Update ycql driver version to 4.19.0-yb-1
- Make required changes in the imports
- This connector version will be published as 3.3-yb-4

## Testing 
Ran following tests from yugabyte-db repo:
```
mvn test -Dtest=org.yb.loadtest.TestTupleOperators
mvn test -Dtest=org.yb.loadtest.TestCassandraSpark3WordCount
mvn test -Dtest=org.yb.loadtest.TestSpark3Locality
mvn test -Dtest=org.yb.loadtest.TestSpark3Jsonb
```